### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ decompress the source code, or clone the github repository:
 
     $ git clone git://github.com/peterjc/backports.lzma.git
     $ cd backports.lzma
-    $ python setup.py install
+    $ sudo python setup.py install
     $ cd test
     $ python test_lzma.py
 


### PR DESCRIPTION
Without "sudo" command, the python setup.py script will return the follow error:

creating /usr/local/lib/python2.7/dist-packages/backports
error: could not create '/usr/local/lib/python2.7/dist-packages/backports': Permission denied